### PR TITLE
feat: add booking analytics dashboard

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,5 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -34,6 +31,6 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".next", "build", "public"]
+    "includes": ["src/**"]
   }
 }

--- a/src/pages/api/users/metrics.api.ts
+++ b/src/pages/api/users/metrics.api.ts
@@ -1,0 +1,93 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/prisma'
+import { buildNextAuthOptions } from '@/pages/api/auth/[...nextauth].api'
+
+export interface MetricsResponse {
+  totalBookings: number
+  bookingsByDayOfWeek: { day: number; dayLabel: string; count: number }[]
+  bookingsByHour: { hour: number; count: number }[]
+  busiestDay: { dayLabel: string; count: number } | null
+  busiestHour: { hour: number; count: number } | null
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).end()
+  }
+
+  const session = await getServerSession(
+    req,
+    res,
+    buildNextAuthOptions(req, res),
+  )
+
+  if (!session) {
+    return res.status(401).end()
+  }
+
+  const userId = session.user.id
+
+  const totalBookings = await prisma.scheduling.count({
+    where: { user_id: userId },
+  })
+
+  const bookingsByDayOfWeek = await prisma.scheduling.groupBy({
+    by: ['date'],
+    where: { user_id: userId },
+    _count: { id: true },
+  })
+
+  const dayAggregated: Record<number, number> = {}
+  const hourAggregated: Record<number, number> = {}
+
+  for (const booking of bookingsByDayOfWeek) {
+    const date = new Date(booking.date)
+    const dayOfWeek = date.getDay()
+    const hour = date.getHours()
+
+    dayAggregated[dayOfWeek] =
+      (dayAggregated[dayOfWeek] || 0) + booking._count.id
+    hourAggregated[hour] = (hourAggregated[hour] || 0) + booking._count.id
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' })
+  const dayLabels = Array.from(Array(7).keys())
+    .map((day) => formatter.format(new Date(Date.UTC(2021, 5, day))))
+    .map((d) => d.substring(0, 3))
+
+  const dayResult: { day: number; dayLabel: string; count: number }[] =
+    Array.from(Array(7).keys()).map((day) => ({
+      day,
+      dayLabel: dayLabels[day],
+      count: dayAggregated[day] || 0,
+    }))
+
+  const hourResult: { hour: number; count: number }[] = Array.from(
+    Array(24).keys(),
+  ).map((hour) => ({
+    hour,
+    count: hourAggregated[hour] || 0,
+  }))
+
+  const busiestDay = dayResult.reduce(
+    (max, curr) => (curr.count > (max?.count || 0) ? curr : max),
+    null as { day: number; dayLabel: string; count: number } | null,
+  )
+
+  const busiestHour = hourResult.reduce(
+    (max, curr) => (curr.count > (max?.count || 0) ? curr : max),
+    null as { hour: number; count: number } | null,
+  )
+
+  return res.status(200).json({
+    totalBookings,
+    bookingsByDayOfWeek: dayResult,
+    bookingsByHour: hourResult,
+    busiestDay: busiestDay && busiestDay.count > 0 ? busiestDay : null,
+    busiestHour: busiestHour && busiestHour.count > 0 ? busiestHour : null,
+  } satisfies MetricsResponse)
+}

--- a/src/pages/register/dashboard/index.page.tsx
+++ b/src/pages/register/dashboard/index.page.tsx
@@ -1,0 +1,193 @@
+import { Button, Heading, Text } from '@rafaumeu-ignite-ui/react'
+import { useQuery } from '@tanstack/react-query'
+import type { GetServerSideProps } from 'next'
+import { useRouter } from 'next/router'
+import { getServerSession } from 'next-auth'
+import { useSession } from 'next-auth/react'
+import { NextSeo } from 'next-seo'
+import { ArrowLeft, ChartBar } from 'phosphor-react'
+import { api } from '@/lib/axios'
+import { buildNextAuthOptions } from '@/pages/api/auth/[...nextauth].api'
+import type { MetricsResponse } from '@/pages/api/users/metrics.api'
+import {
+  Bar,
+  BarGroup,
+  BarLabel,
+  BarValue,
+  ChartContainer,
+  ChartSection,
+  ChartTitle,
+  Container,
+  EmptyState,
+  Header,
+  Navigation,
+  StatCard,
+  StatLabel,
+  StatsGrid,
+  StatValue,
+} from './styles'
+
+export default function Dashboard() {
+  const session = useSession()
+  const router = useRouter()
+
+  const { data: metrics, isLoading } = useQuery<MetricsResponse>({
+    queryKey: ['userMetrics'],
+    queryFn: async () => {
+      const response = await api.get('/users/metrics')
+      return response.data
+    },
+    enabled: session.status === 'authenticated',
+  })
+
+  if (isLoading) {
+    return (
+      <>
+        <NextSeo title="Dashboard | Ignite Call" noindex />
+        <Container>
+          <Header>
+            <Heading as="strong">Booking Analytics</Heading>
+            <Text>Loading your metrics...</Text>
+          </Header>
+        </Container>
+      </>
+    )
+  }
+
+  const maxDayCount = Math.max(
+    ...(metrics?.bookingsByDayOfWeek.map((d) => d.count) || [1]),
+    1,
+  )
+  const maxHourCount = Math.max(
+    ...(metrics?.bookingsByHour.map((h) => h.count) || [1]),
+    1,
+  )
+
+  const activeHours = metrics?.bookingsByHour.filter((h) => h.count > 0) || []
+
+  return (
+    <>
+      <NextSeo title="Dashboard | Ignite Call" noindex />
+      <Container>
+        <Navigation>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => router.push('/register/update-profile')}
+          >
+            <ArrowLeft />
+            Back to Profile
+          </Button>
+        </Navigation>
+
+        <Header>
+          <Heading as="strong">
+            <ChartBar style={{ marginRight: 8, verticalAlign: 'middle' }} />
+            Booking Analytics
+          </Heading>
+          <Text>
+            Track your scheduling performance. See when your bookings peak and
+            optimize your availability.
+          </Text>
+        </Header>
+
+        {metrics && metrics.totalBookings > 0 ? (
+          <>
+            <StatsGrid>
+              <StatCard>
+                <StatValue>{metrics.totalBookings}</StatValue>
+                <StatLabel>Total Bookings</StatLabel>
+              </StatCard>
+              <StatCard>
+                <StatValue>{metrics.busiestDay?.dayLabel || '—'}</StatValue>
+                <StatLabel>
+                  Busiest Day{' '}
+                  {metrics.busiestDay
+                    ? `(${metrics.busiestDay.count} bookings)`
+                    : ''}
+                </StatLabel>
+              </StatCard>
+              <StatCard>
+                <StatValue>
+                  {metrics.busiestHour ? `${metrics.busiestHour.hour}:00` : '—'}
+                </StatValue>
+                <StatLabel>
+                  Busiest Hour{' '}
+                  {metrics.busiestHour
+                    ? `(${metrics.busiestHour.count} bookings)`
+                    : ''}
+                </StatLabel>
+              </StatCard>
+            </StatsGrid>
+
+            <ChartSection>
+              <ChartTitle>Bookings by Day of Week</ChartTitle>
+              <ChartContainer>
+                {metrics.bookingsByDayOfWeek.map((day) => (
+                  <BarGroup key={day.day}>
+                    {day.count > 0 && <BarValue>{day.count}</BarValue>}
+                    <Bar
+                      style={{
+                        height: `${(day.count / maxDayCount) * 120}px`,
+                      }}
+                    />
+                    <BarLabel>{day.dayLabel}</BarLabel>
+                  </BarGroup>
+                ))}
+              </ChartContainer>
+            </ChartSection>
+
+            {activeHours.length > 0 && (
+              <ChartSection>
+                <ChartTitle>Bookings by Time Slot</ChartTitle>
+                <ChartContainer>
+                  {activeHours.map((slot) => (
+                    <BarGroup key={slot.hour}>
+                      <BarValue>{slot.count}</BarValue>
+                      <Bar
+                        style={{
+                          height: `${(slot.count / maxHourCount) * 120}px`,
+                        }}
+                      />
+                      <BarLabel>{`${slot.hour}:00`}</BarLabel>
+                    </BarGroup>
+                  ))}
+                </ChartContainer>
+              </ChartSection>
+            )}
+          </>
+        ) : (
+          <EmptyState>
+            <Text>
+              No bookings yet. Share your scheduling link to start receiving
+              appointments!
+            </Text>
+          </EmptyState>
+        )}
+      </Container>
+    </>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  const session = await getServerSession(
+    req,
+    res,
+    buildNextAuthOptions(req, res),
+  )
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/register/connect-calendar',
+        permanent: false,
+      },
+    }
+  }
+
+  return {
+    props: {
+      session,
+    },
+  }
+}

--- a/src/pages/register/dashboard/styles.ts
+++ b/src/pages/register/dashboard/styles.ts
@@ -1,0 +1,115 @@
+import { Box, Heading, styled, Text } from '@rafaumeu-ignite-ui/react'
+
+export const Container = styled('main', {
+  maxWidth: 852,
+  margin: '$20 auto $4',
+  padding: '0 $4',
+})
+
+export const Header = styled('div', {
+  padding: '0 $6',
+  marginBottom: '$8',
+  [`> ${Heading}`]: {
+    lineHeight: '$base',
+  },
+  [`> ${Text}`]: {
+    color: '$gray200',
+    marginTop: '$2',
+  },
+})
+
+export const StatsGrid = styled('div', {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '$4',
+  marginBottom: '$8',
+
+  '@media(max-width: 600px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+export const StatCard = styled(Box, {
+  padding: '$6',
+  textAlign: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '$2',
+})
+
+export const StatValue = styled(Heading, {
+  fontSize: '$3xl',
+  color: '$ignite100',
+  lineHeight: '$base',
+})
+
+export const StatLabel = styled(Text, {
+  color: '$gray200',
+  fontSize: '$sm',
+})
+
+export const ChartSection = styled(Box, {
+  padding: '$6',
+  marginBottom: '$6',
+})
+
+export const ChartTitle = styled(Text, {
+  marginBottom: '$4',
+  fontWeight: 'bold',
+  color: '$gray100',
+})
+
+export const ChartContainer = styled('div', {
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: '$2',
+  height: 160,
+  paddingBottom: '$4',
+  paddingTop: '$4',
+})
+
+export const BarGroup = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  flex: 1,
+  gap: '$2',
+  minWidth: 0,
+})
+
+export const Bar = styled('div', {
+  width: '100%',
+  maxWidth: 48,
+  backgroundColor: '$ignite500',
+  borderRadius: '$sm $sm 0 0',
+  transition: 'height 0.3s ease',
+  minHeight: 2,
+
+  '&:hover': {
+    backgroundColor: '$ignite300',
+  },
+})
+
+export const BarLabel = styled(Text, {
+  fontSize: '$xs',
+  color: '$gray400',
+  textAlign: 'center',
+  whiteSpace: 'nowrap',
+})
+
+export const BarValue = styled(Text, {
+  fontSize: '$xs',
+  color: '$gray200',
+})
+
+export const EmptyState = styled(Box, {
+  padding: '$8',
+  textAlign: 'center',
+})
+
+export const Navigation = styled('div', {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  padding: '0 $6',
+  marginBottom: '$4',
+})

--- a/src/pages/register/update-profile/index.page.tsx
+++ b/src/pages/register/update-profile/index.page.tsx
@@ -1,8 +1,20 @@
-import { Button, TextArea, TextInput } from '@rafaumeu-ignite-ui/react'
-import { MultiStep } from '@rafaumeu-ignite-ui/react'
-import { Text } from '@rafaumeu-ignite-ui/react'
-import { Heading } from '@rafaumeu-ignite-ui/react'
-
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Avatar,
+  Button,
+  Heading,
+  MultiStep,
+  Text,
+  TextArea,
+} from '@rafaumeu-ignite-ui/react'
+import type { GetServerSideProps } from 'next'
+import { useRouter } from 'next/router'
+import { getServerSession } from 'next-auth'
+import { useSession } from 'next-auth/react'
+import { NextSeo } from 'next-seo'
+import { ArrowRight, ChartBar } from 'phosphor-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
 import { api } from '@/lib/axios'
 import { buildNextAuthOptions } from '@/pages/api/auth/[...nextauth].api'
 import { Container, Header } from '@/pages/register/style'
@@ -10,16 +22,6 @@ import {
   FormAnnotation,
   ProfileBox,
 } from '@/pages/register/update-profile/styles'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { Avatar } from '@rafaumeu-ignite-ui/react'
-import type { GetServerSideProps } from 'next'
-import { getServerSession } from 'next-auth'
-import { useSession } from 'next-auth/react'
-import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
-import { ArrowRight } from 'phosphor-react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 
 const updateFormSchema = z.object({
   bio: z.string(),
@@ -74,6 +76,14 @@ export default function UpdateProfile() {
           <Button type="submit" disabled={isSubmitting}>
             Finalizar
             <ArrowRight />
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => router.push('/register/dashboard')}
+          >
+            <ChartBar />
+            View Booking Analytics
           </Button>
         </ProfileBox>
       </Container>


### PR DESCRIPTION
## What
Adds a Booking Analytics Dashboard page at `/register/dashboard` that shows:
- Total bookings count
- Busiest day of week  
- Busiest time slot hour
- CSS bar charts for bookings by day and by hour

## Why
Transforms the app from a course project into a real product by giving users actionable insight into their scheduling patterns. Users can optimize availability based on actual booking data.

## Changes
- New API: `GET /api/users/metrics` (Prisma aggregation, auth-protected)
- New page: `/register/dashboard` (React Query, CSS bar charts, protected route)
- Modified: `/register/update-profile` (added Dashboard navigation button)
- Fixed: `biome.json` for Biome v2 compatibility
- No new dependencies added